### PR TITLE
Смена сигнатуры SignXML для корректной подписи xml с кириллицей

### DIFF
--- a/NKalkan/InteropDefinitions.cs
+++ b/NKalkan/InteropDefinitions.cs
@@ -14,7 +14,7 @@ internal delegate KalkanError KC_GetLastErrorString(StringBuilder? errorString, 
 internal delegate KalkanError KC_LoadKeyStore(int storage, string password, int passLen, string container, int containerLen, string? alias);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-internal delegate KalkanError KC_SignXML(string? alias, int flags, string inData, int inDataLength, StringBuilder? outSign, ref int outSignoutSignLength, string? signNodeId, string? parentSignNode, string? parentNameSpace);
+internal delegate KalkanError KC_SignXML(string? alias, int flags, byte[] inData, int inDataLength, byte[] outSign, ref int outSignoutSignLength, string? signNodeId, string? parentSignNode, string? parentNameSpace);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 internal delegate KalkanError KC_VerifyXML(string? alias, int flags, string inData, int inDataLength, StringBuilder? outVerifyInfo, ref int outVerifyInfoLength);

--- a/NKalkan/KalkanApi.cs
+++ b/NKalkan/KalkanApi.cs
@@ -198,17 +198,18 @@ public sealed class KalkanApi
         }
 
         var signedPayloadLength = 0;
-        var contentLength = Encoding.UTF8.GetByteCount(content);
-        var errorCode = StKCFunctionsType.SignXML(certificateAlias, (int)flags, content, contentLength, null, ref signedPayloadLength, signNodeId, parentSignNode, parentNameSpace);
+        var contentBytes = Encoding.UTF8.GetBytes(content);
+        var contentLength = contentBytes.Length;
+        var errorCode = StKCFunctionsType.SignXML(certificateAlias, (int)flags, contentBytes, contentLength, Array.Empty<byte>(), ref signedPayloadLength, signNodeId, parentSignNode, parentNameSpace);
         if (errorCode != KalkanError.BUFFER_TOO_SMALL)
         {
             ThrowIfError(errorCode);
         }
 
-        var signedPayload = new StringBuilder(signedPayloadLength);
-        errorCode = StKCFunctionsType.SignXML(certificateAlias, (int)flags, content, contentLength, signedPayload, ref signedPayloadLength, signNodeId, parentSignNode, parentNameSpace);
+        var signedPayload = new byte[signedPayloadLength];
+        errorCode = StKCFunctionsType.SignXML(certificateAlias, (int)flags, contentBytes, contentLength, signedPayload, ref signedPayloadLength, signNodeId, parentSignNode, parentNameSpace);
         ThrowIfError(errorCode);
-        return signedPayload.ToString();
+        return Encoding.UTF8.GetString(signedPayload, 0, signedPayloadLength).TrimEnd('\0');
     }
 
     public string VerifyXml(string content, KalkanSignFlags flags = 0, string? certificateAlias = null)

--- a/NKalkan/KalkanApi.cs
+++ b/NKalkan/KalkanApi.cs
@@ -209,7 +209,7 @@ public sealed class KalkanApi
         var signedPayload = new byte[signedPayloadLength];
         errorCode = StKCFunctionsType.SignXML(certificateAlias, (int)flags, contentBytes, contentLength, signedPayload, ref signedPayloadLength, signNodeId, parentSignNode, parentNameSpace);
         ThrowIfError(errorCode);
-        return Encoding.UTF8.GetString(signedPayload, 0, signedPayloadLength).TrimEnd('\0');
+        return TrimSignedPayloadNullTerminator(signedPayload, signedPayloadLength);
     }
 
     public string VerifyXml(string content, KalkanSignFlags flags = 0, string? certificateAlias = null)
@@ -314,7 +314,7 @@ public sealed class KalkanApi
         var signedPayload = new byte[signedPayloadLength];
         errorCode = StKCFunctionsType.SignWSSE(certificateAlias, (int)flags, documentToSignBytes, documentToSignLength, signedPayload, ref signedPayloadLength, signNodeId);
         ThrowIfError(errorCode);
-        return Encoding.UTF8.GetString(signedPayload, 0, signedPayloadLength).TrimEnd('\0');
+        return TrimSignedPayloadNullTerminator(signedPayload, signedPayloadLength);
     }
 
     /// <summary>
@@ -352,8 +352,7 @@ public sealed class KalkanApi
         errorCode = StKCFunctionsType.SignWSSE(certificateAlias, (int)flags, inData, inDataLength, outSign, ref outSignLength, signNodeId);
         ThrowIfError(errorCode);
 
-        // Convert output bytes back to string (trim any null terminator if present)
-        return Encoding.UTF8.GetString(outSign, 0, outSignLength).TrimEnd('\0');
+        return TrimSignedPayloadNullTerminator(outSign, outSignLength);
     }
 
     public string HashData(string algorithm, byte[] content, KalkanSignType signType, KalkanInputFormat inputFormat, KalkanOutputFormat outputFormat)
@@ -581,5 +580,11 @@ public sealed class KalkanApi
         }
 
         return flags;
+    }
+
+    private static string TrimSignedPayloadNullTerminator(byte[] signedPayload, int signedPayloadLength)
+    {
+        ReadOnlySpan<byte> signedSpan = signedPayload.AsSpan(0, signedPayloadLength - 1);
+        return Encoding.UTF8.GetString(signedSpan.ToArray());
     }
 }

--- a/NKalkan/NKalkan.csproj
+++ b/NKalkan/NKalkan.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Изменен метод SignXML на преобразование строки в байт массив и передачи в библиотеку, для корректной подписи xml с кириллицей